### PR TITLE
Refactor/lenv

### DIFF
--- a/rispreter-repl/src/eval.rs
+++ b/rispreter-repl/src/eval.rs
@@ -6,3 +6,29 @@ use rispreter_parser::parse_risp;
 pub fn eval_rispreter(lenv: &mut Lenv, input: String) -> Lval {
     lval_eval(lenv, &mut read(parse_risp(input.as_bytes())))
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    // use crate::lval::lval_eval::*;
+    // use crate::lval::lval_def::*;
+    use crate::read::read;
+    use crate::lval::lval_builtin::Lbuiltin;
+    use rispreter_parser::parse_risp;
+
+    #[test]
+    fn test_parent_env_keeps_lvals_defined_inside_lambdas() {
+        let mut env = Lenv::new();
+        Lbuiltin::add_builtins(&mut env);
+        let fun_def = "(def {fun} (\\ {args body} {def (head args) (\\ (tail args) body)}))\n".to_string();
+        let eval1 = eval_rispreter(&mut env, fun_def);
+        assert_eq!(Lval::lval_sexpr(), eval1);
+        assert_eq!(true, env.contains("fun".to_string()));
+
+        let fun_usage = "(fun {add-togheter x y} {+ x y})".to_string();
+        let eval2 = eval_rispreter(&mut env, fun_usage);
+        println!("{:?}", eval2);
+        assert_eq!(true, env.contains("add-togheter".to_string()));
+    }
+}

--- a/rispreter-repl/src/eval.rs
+++ b/rispreter-repl/src/eval.rs
@@ -1,5 +1,6 @@
 use crate::lval::lval_eval::*;
 use crate::lval::lval_def::*;
+use crate::lval::lval_env::Lenv;
 use crate::read::read;
 use rispreter_parser::parse_risp;
 
@@ -16,6 +17,7 @@ pub mod tests {
     use crate::read::read;
     use crate::lval::lval_builtin::Lbuiltin;
     use rispreter_parser::parse_risp;
+    use crate::lval::lval_env::Lenv;
 
     #[test]
     fn test_parent_env_keeps_lvals_defined_inside_lambdas() {

--- a/rispreter-repl/src/lib.rs
+++ b/rispreter-repl/src/lib.rs
@@ -5,3 +5,4 @@ pub mod read;
 pub mod eval;
 pub mod lval;
 pub mod repl;
+pub mod refnode;

--- a/rispreter-repl/src/lval/lval_builtin.rs
+++ b/rispreter-repl/src/lval/lval_builtin.rs
@@ -1,5 +1,6 @@
 use crate::lval::lval_def::*;
 use crate::lval::lval_eval;
+use crate::lval::lval_env::Lenv;
 //use crate::lval::lval_lambda::LLambda;
 
 pub struct Lbuiltin(pub fn(lenv: &mut Lenv, lval: &mut Lval) -> Lval, String);
@@ -242,7 +243,8 @@ fn head(_lenv: &mut Lenv, lval: &mut Lval) -> Lval {
          return Lval::lval_error_empty_qexpr("lval_builtin::head".to_string(), qexpr)
     }
 
-    let head = qexpr.lval_pop();
+    let mut head = Lval::lval_qexpr();
+    head.add_cell(qexpr.lval_pop());
     head
 }
 
@@ -403,8 +405,8 @@ fn put(env: &mut Lenv, lval: &mut Lval) -> Lval {
 }
 
 fn var(env: &mut Lenv, lval: &mut Lval, func: &str) -> Lval {
-    if lval.cell[0].cell.len() == 0 {
-        return Lval::lval_error_empty_qexpr("lval_builtin::var".to_string(), *lval.cell[0].clone())
+    if let LvalType::LVAL_QEXPR = &lval.cell[0].ltype {} else {
+        return Lval::lval_err(format!("not a Q-expression got {}, expect {}", lval.ltype, LvalType::LVAL_QEXPR))
     }
     let left_len = lval.cell[0].cell.len();
     let mut right_len = 0;
@@ -431,10 +433,10 @@ fn var(env: &mut Lenv, lval: &mut Lval, func: &str) -> Lval {
         if let LvalType::LVAL_SYM(str) = &symbols_list.cell[i].ltype {
             match func {
                 "def" => {
-                    env.def(str.to_string(), lval.cell[i].clone());
+                    env.def(str.to_string(), *lval.cell[i].clone());
                 },
                 "put" => {
-                    env.put(str.to_string(), lval.cell[i].clone());
+                    env.put(str.to_string(), *lval.cell[i].clone());
                 },
                 _ => {
 

--- a/rispreter-repl/src/lval/lval_builtin.rs
+++ b/rispreter-repl/src/lval/lval_builtin.rs
@@ -239,7 +239,7 @@ fn head(_lenv: &mut Lenv, lval: &mut Lval) -> Lval {
     }
 
     if qexpr.cell.len() == 0 {
-         return Lval::lval_error_empty_qexpr()
+         return Lval::lval_error_empty_qexpr("lval_builtin::head".to_string(), qexpr)
     }
 
     let head = qexpr.lval_pop();
@@ -270,7 +270,7 @@ fn tail(_env: &mut Lenv, lval: &mut Lval) ->  Lval {
 
 
     if qexpr.cell.len() == 0 {
-         return Lval::lval_error_empty_qexpr()
+         return Lval::lval_error_empty_qexpr("lval_builtin::tail".to_string(), qexpr)
     }
 
     let tail = qexpr.lval_split(1);
@@ -319,11 +319,11 @@ fn join(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 
     let mut y = lval.lval_pop();
     if y.cell.len() == 0 {
-         return Lval::lval_error_empty_qexpr()
+         return Lval::lval_error_empty_qexpr("right arg at lval_builtin::join".to_string(), y)
     }
     let mut x = lval.lval_pop();
     if x.cell.len() == 0 {
-         return Lval::lval_error_empty_qexpr()
+         return Lval::lval_error_empty_qexpr("left arg at lval_builtin::join".to_string(), x)
     }
 
     y.cell.append(&mut x.cell);
@@ -404,7 +404,7 @@ fn put(env: &mut Lenv, lval: &mut Lval) -> Lval {
 
 fn var(env: &mut Lenv, lval: &mut Lval, func: &str) -> Lval {
     if lval.cell[0].cell.len() == 0 {
-        return Lval::lval_error_empty_qexpr()
+        return Lval::lval_error_empty_qexpr("lval_builtin::var".to_string(), *lval.cell[0].clone())
     }
     let left_len = lval.cell[0].cell.len();
     let mut right_len = 0;

--- a/rispreter-repl/src/lval/lval_builtin.rs
+++ b/rispreter-repl/src/lval/lval_builtin.rs
@@ -103,6 +103,7 @@ impl std::fmt::Debug for Lbuiltin {
 /// Add n arguments
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -119,6 +120,7 @@ fn add(lenv: &mut Lenv, lval: &mut Lval,) -> Lval {
 /// Subtracts n arguments
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -135,6 +137,7 @@ fn sub(lenv: &mut Lenv, lval: &mut Lval,) -> Lval {
 /// Multiply n arguments
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -152,6 +155,7 @@ fn mul(lenv: &mut Lenv, lval: &mut Lval,) -> Lval {
 /// returns a `LvalType::LVAL_ERR("Division by zero")` if trying to divides by 0
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -171,6 +175,7 @@ fn div(lenv: &mut Lenv, lval: &mut Lval,) -> Lval {
 /// Modulo operand of n arguments
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -220,6 +225,7 @@ fn op(_lenv: &mut Lenv, lval: &mut Lval, op: char) -> Lval {
 /// Take the head of a Q-expression
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -227,7 +233,7 @@ fn op(_lenv: &mut Lenv, lval: &mut Lval, op: char) -> Lval {
 /// Lbuiltin::add_builtins(&mut builtins);
 ///
 /// let res = eval_rispreter(&mut builtins, "(head {1 2 3})".to_string());
-/// assert_eq!(1f64, res);
+/// assert_eq!(1f64, *res.cell[0]);
 /// ```
 fn head(_lenv: &mut Lenv, lval: &mut Lval) -> Lval {
     if lval.cell.len() > 1 {
@@ -251,6 +257,7 @@ fn head(_lenv: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Take the tail (all but first) of a Q-expression
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -258,7 +265,7 @@ fn head(_lenv: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Lbuiltin::add_builtins(&mut builtins);
 ///
 /// let head_of_tail = eval_rispreter(&mut builtins, "(head (tail {1 2 3}))".to_string());
-/// assert_eq!(2f64, head_of_tail);
+/// assert_eq!(2f64, *head_of_tail.cell[0]);
 /// ```
 fn tail(_env: &mut Lenv, lval: &mut Lval) ->  Lval {
     if lval.cell.len() > 1 {
@@ -282,6 +289,7 @@ fn tail(_env: &mut Lenv, lval: &mut Lval) ->  Lval {
 /// Transform all following arguments in a Q-expression
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -289,7 +297,7 @@ fn tail(_env: &mut Lenv, lval: &mut Lval) ->  Lval {
 /// Lbuiltin::add_builtins(&mut builtins);
 ///
 /// let res = eval_rispreter(&mut builtins, "(head (list 1 2 3))".to_string());
-/// assert_eq!(1f64, res);
+/// assert_eq!(1f64, *res.cell[0]);
 /// ```
 pub fn list(_env: &mut Lenv, lval: &mut Lval) -> Lval {
     lval.ltype = LvalType::LVAL_QEXPR;
@@ -299,6 +307,7 @@ pub fn list(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Joins two Q-expressions, where the first is joined in the left side of the second
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -306,7 +315,7 @@ pub fn list(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Lbuiltin::add_builtins(&mut builtins);
 ///
 /// let res = eval_rispreter(&mut builtins, "(head (join {1} {2 3}))".to_string());
-/// assert_eq!(1f64, res);
+/// assert_eq!(1f64, *res.cell[0]);
 /// ```
 fn join(_env: &mut Lenv, lval: &mut Lval) -> Lval {
     if lval.cell.len() != 2 {
@@ -335,6 +344,7 @@ fn join(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// The classic cons, put a element in a Q-expression
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -342,7 +352,7 @@ fn join(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Lbuiltin::add_builtins(&mut builtins);
 ///
 /// let res = eval_rispreter(&mut builtins, "(head (cons 1 {2 3}))".to_string());
-/// assert_eq!(1f64, res);
+/// assert_eq!(1f64, *res.cell[0]);
 /// ```
 fn cons(_env: &mut Lenv, lval: &mut Lval) -> Lval {
     if lval.cell.len() != 2 {
@@ -360,6 +370,7 @@ fn cons(_env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Evaluates a Q-expression, basicaly it transforms a Q-expr into a S-expr
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -390,6 +401,7 @@ fn def(env: &mut Lenv, lval: &mut Lval) -> Lval {
 /// Binds the n symbols of an Q-expression in its followings bindings.
 /// # Examples
 /// ```
+/// # use rispreter_repl::lval::lval_env::Lenv;
 /// # use rispreter_repl::eval::eval_rispreter;
 /// # use rispreter_repl::lval::lval_builtin::*;
 /// # use rispreter_repl::lval::lval_def::*;
@@ -398,7 +410,7 @@ fn def(env: &mut Lenv, lval: &mut Lval) -> Lval {
 ///
 /// eval_rispreter(&mut builtins, "(def {x} {1 2 3})".to_string());
 /// let res = eval_rispreter(&mut builtins, "(head x)".to_string());
-/// assert_eq!(1f64, res);
+/// assert_eq!(1f64, *res.cell[0]);
 /// ```
 fn put(env: &mut Lenv, lval: &mut Lval) -> Lval {
     var(env, lval, "=")
@@ -548,7 +560,8 @@ mod tests {
         top.add_cell(head_op).add_cell(qexpr);
         top.lval_pop();
         top = head(&mut lenv, &mut top);
-        assert_eq!(top.ltype, LvalType::LVAL_NUM(1.0));
+        println!("{}", top);
+        assert_eq!(top.cell[0].ltype, LvalType::LVAL_NUM(1.0));
     }
 
     #[test]

--- a/rispreter-repl/src/lval/lval_def.rs
+++ b/rispreter-repl/src/lval/lval_def.rs
@@ -2,11 +2,11 @@ use crate::lval::lval_builtin::*;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fmt;
-
+use crate::lval::lval_env::Lenv;
 use crate::lval::lval_lambda::LLambda;
 
 #[allow(non_camel_case_types)] // please
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Clone)]
 pub enum LvalType {
     LVAL_ERR(String),
     LVAL_NUM(f64),
@@ -50,7 +50,39 @@ impl fmt::Display for LvalType {
     }
 }
 
-#[derive(PartialEq, Debug, Clone)]
+impl fmt::Debug for LvalType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LvalType::LVAL_ERR(err) => {
+                write!(f, "error: \"{}\"", err)
+            },
+            LvalType::LVAL_NUM(num) => {
+                write!(f, "{}", num)
+            },
+            LvalType::LVAL_SYM(sym) => {
+                write!(f, "{}", sym)
+            },
+            LvalType::LVAL_STRING(str) => {
+                write!(f, "\"{}\"", str)
+            }
+            LvalType::LVAL_FUN(fun) => {
+                write!(f, "{:?}", fun)
+            },
+            LvalType::LVAL_LAMBDA(lambda) => {
+                write!(f, "body: {:?}\n", lambda.body.cell)?;
+                write!(f, "formals: {:?}", lambda.formals.cell)
+            },
+            LvalType::LVAL_SEXPR => {
+                write!(f, "()")
+            },
+            LvalType::LVAL_QEXPR => {
+                write!(f, "{{}}")
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Clone)]
 pub struct Lval {
     pub ltype: LvalType,
     pub cell: VecDeque<Box<Lval>>,
@@ -190,6 +222,38 @@ impl fmt::Display for Lval {
     }
 }
 
+impl fmt::Debug for Lval {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.ltype {
+            LvalType::LVAL_SEXPR => {
+                if self.cell.len() == 0 {
+                    write!(f, "{}", self.ltype)
+                } else {
+                    write!(f, "(")?;
+                    for elem in self.cell.iter() {
+                        write!(f, " {} ", elem)?;
+                    };
+                    write!(f, ")")
+                }
+            },
+            LvalType::LVAL_QEXPR => {
+                if self.cell.len() == 0 {
+                    write!(f, "{}", self.ltype)
+                } else {
+                    write!(f, "{{")?;
+                    for elem in self.cell.iter() {
+                        write!(f, " {} ", elem)?;
+                    };
+                    write!(f, "}}")
+                }
+            },
+            _ => {
+                write!(f, "{}", self.ltype)
+            }
+        }
+    }
+}
+
 impl From<Lval> for Option<String> {
     fn from(v: Lval) -> Option<String> {
         match v.ltype {
@@ -220,69 +284,67 @@ impl PartialEq<Lval> for f64 {
         }
     }
 }
-
-#[derive(PartialEq, Debug, Clone)]
-pub struct Lenv {
-    pub paren_env: Option<Box<Lenv>>,
-    vals: HashMap<String, Box<Lval>>,
-}
-
-impl Lenv {
-    pub fn new() -> Lenv {
-        Lenv {
-            paren_env: None,
-            vals: HashMap::new(),
-        }
-    }
-
-    pub fn add_builtin(&mut self, name: &str, func: Lbuiltin) {
-        let lval = Lval::lval_fun(func);
-        self.vals.insert(name.to_string(), Box::new(lval));
-    }
-
-    pub fn get(&self, k: &String) -> Option<&Box<Lval>> {
-        match self.vals.get(k) {
-            Some(ref mut sym) => {
-                Some(sym)
-            },
-            None => {
-                match self.paren_env {
-                    Some(ref paren_sym) => {
-                        paren_sym.get(k)
-                    },
-                    None => {
-                        None
-                    }
-                }
-            }
-        }
-    }
-
-    pub fn put(&mut self, k: String, v: Box<Lval>) {
-        self.vals.insert(k, v);
-    }
-
-    // did you got that recursion? :-O
-    // lets test...
-    // *goes to write a test*
-    // *test pass*
-    // ok, it's working for now... ;)
-    pub fn def(&mut self, k: String, v: Box<Lval>) -> Option<()> {
-        match self.paren_env {
-            Some(ref mut paren) => {
-                paren.def(k, v)
-            },
-            None => {
-                self.put(k, v);
-                None
-            }
-        }
-    }
-
-    pub fn contains(&self, k: String) -> bool {
-        self.vals.contains_key(&k)
-    }
-}
+//
+// #[derive(PartialEq, Debug, Clone)]
+// pub struct Lenv {
+//     vals: HashMap<String, Box<Lval>>,
+// }
+//
+// impl Lenv {
+//     pub fn new() -> Lenv {
+//         Lenv {
+//             vals: HashMap::new(),
+//         }
+//     }
+//
+//     pub fn add_builtin(&mut self, name: &str, func: Lbuiltin) {
+//         let lval = Lval::lval_fun(func);
+//         self.vals.insert(name.to_string(), Box::new(lval));
+//     }
+//
+//     pub fn get(&self, k: &String) -> Option<&Box<Lval>> {
+//         match self.vals.get(k) {
+//             Some(ref mut sym) => {
+//                 Some(sym)
+//             },
+//             None => {
+//                 match self.paren_env {
+//                     Some(ref paren_sym) => {
+//                         paren_sym.get(k)
+//                     },
+//                     None => {
+//                         None
+//                     }
+//                 }
+//             }
+//         }
+//     }
+//
+//     pub fn put(&mut self, k: String, v: Box<Lval>) {
+//         self.vals.insert(k, v);
+//     }
+//
+//     // did you got that recursion? :-O
+//     // lets test...
+//     // *goes to write a test*
+//     // *test pass*
+//     // ok, it's working for now... ;)
+//     pub fn def(&mut self, k: String, v: Box<Lval>) -> Option<()> {
+//         match self.paren_env {
+//             Some(ref mut paren) => {
+//                 paren.def(k, v)
+//             },
+//             None => {
+//                 self.put(k, v);
+//                 None
+//             }
+//         }
+//     }
+//
+//     pub fn contains(&self, k: String) -> bool {
+//         self.vals.contains_key(&k)
+//     }
+// }
 
 #[cfg(test)]
 pub mod tests {
@@ -309,30 +371,30 @@ pub mod tests {
         assert_eq!(lval.ltype, LvalType::LVAL_QEXPR);
     }
 
-    #[test]
-    fn test_lenv_def() {
-        let k = String::from("x");
-        let v = Box::new(Lval::lval_num(1.0));
-        let mut lenv = Lenv::new();
-        lenv.paren_env = Some(Box::new(Lenv::new()));
-        lenv.def(k, v);
-        assert_eq!(Some(&Box::new(Lval::lval_num(1.0))), lenv.paren_env.unwrap().get(&String::from("x")));
-    }
+    // #[test]
+    // fn test_lenv_def() {
+    //     let k = String::from("x");
+    //     let v = Box::new(Lval::lval_num(1.0));
+    //     let mut lenv = Lenv::new();
+    //     lenv.paren_env = Some(Box::new(Lenv::new()));
+    //     lenv.def(k, v);
+    //     assert_eq!(Some(&Box::new(Lval::lval_num(1.0))), lenv.paren_env.unwrap().get(&String::from("x")));
+    // }
 
-    #[test]
-    fn test_lenv_def_and_local_lenv() {
-        let k = String::from("x");
-        let v = Box::new(Lval::lval_num(1.0));
-        let v_local = Box::new(Lval::lval_string("local_sym".to_string()));
-
-        let mut lenv = Lenv::new();
-
-        lenv.put(String::from("x"), v_local);
-
-        lenv.paren_env = Some(Box::new(Lenv::new()));
-        lenv.def(k, v);
-        assert_eq!(Some(&Box::new(Lval::lval_num(1.0))), lenv.paren_env.clone().unwrap().get(&String::from("x")));
-        assert_eq!(Some(&Box::new(Lval::lval_string("local_sym".to_string()))), lenv.get(&String::from("x")));
-    }
+    // #[test]
+    // fn test_lenv_def_and_local_lenv() {
+    //     let k = String::from("x");
+    //     let v = Box::new(Lval::lval_num(1.0));
+    //     let v_local = Box::new(Lval::lval_string("local_sym".to_string()));
+    //
+    //     let mut lenv = Lenv::new();
+    //
+    //     lenv.put(String::from("x"), v_local);
+    //
+    //     lenv.paren_env = Some(Box::new(Lenv::new()));
+    //     lenv.def(k, v);
+    //     assert_eq!(Some(&Box::new(Lval::lval_num(1.0))), lenv.paren_env.clone().unwrap().get(&String::from("x")));
+    //     assert_eq!(Some(&Box::new(Lval::lval_string("local_sym".to_string()))), lenv.get(&String::from("x")));
+    // }
 
 }

--- a/rispreter-repl/src/lval/lval_def.rs
+++ b/rispreter-repl/src/lval/lval_def.rs
@@ -153,8 +153,8 @@ impl Lval {
     pub fn lval_error_argssize(a: usize, b: usize) -> Lval {
         Lval::lval_err(format!("Wrong num of args, got {} expect {}", a, b))
     }
-    pub fn lval_error_empty_qexpr() -> Lval {
-        Lval::lval_err(format!("Q-expression is empty!"))
+    pub fn lval_error_empty_qexpr(caller: String, a: Lval) -> Lval {
+        Lval::lval_err(format!("Q-expression is empty!: caller: {}, \n val: {:?}", caller, a))
     }
 }
 
@@ -277,6 +277,10 @@ impl Lenv {
                 None
             }
         }
+    }
+
+    pub fn contains(&self, k: String) -> bool {
+        self.vals.contains_key(&k)
     }
 }
 

--- a/rispreter-repl/src/lval/lval_env.rs
+++ b/rispreter-repl/src/lval/lval_env.rs
@@ -1,3 +1,5 @@
+/// A custom forest tree got from github.com/SimonSapin/rust-forest
+
 use std::cell::{self, RefCell};
 use std::fmt;
 use std::ops::{Deref, DerefMut};

--- a/rispreter-repl/src/lval/lval_env.rs
+++ b/rispreter-repl/src/lval/lval_env.rs
@@ -1,0 +1,685 @@
+use std::cell::{self, RefCell};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::rc::{Rc, Weak};
+use crate::lval::lval_def::Lval;
+use crate::lval::lval_builtin::Lbuiltin;
+use std::collections::HashMap;
+
+/// A reference to a node holding a value of type `T`. Nodes form a tree.
+///
+/// Internally, this uses reference counting for lifetime tracking
+/// and `std::cell::RefCell` for interior mutability.
+///
+/// **Note:** Cloning a `Lenv` only increments a reference count. It does not copy the data.
+#[derive(PartialEq)]
+pub struct Lenv(Rc<RefCell<Node>>);
+
+struct Node {
+    parent: WeakLink,
+    first_child: Link,
+    last_child: WeakLink,
+    previous_sibling: WeakLink,
+    next_sibling: Link,
+    data: HashMap<String, Lval>,
+}
+
+type Link = Option<Rc<RefCell<Node>>>;
+type WeakLink = Option<Weak<RefCell<Node>>>;
+
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Node) -> bool {
+        false
+    }
+}
+
+fn same_rc<T>(a: &Rc<T>, b: &Rc<T>) -> bool {
+    let a: *const T = &**a;
+    let b: *const T = &**b;
+    a == b
+}
+
+
+/// Cloning a `Lenv` only increments a reference count. It does not copy the data.
+impl Clone for Lenv {
+    fn clone(&self) -> Lenv {
+        Lenv(self.0.clone())
+    }
+}
+
+impl fmt::Debug for Lenv {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for child in self.children() {
+            println!("\nchild:");
+            fmt::Debug::fmt(&*child.borrow(), f)?
+        }
+        println!("\nparent:");
+        fmt::Debug::fmt(&*self.borrow(), f)
+    }
+}
+
+macro_rules! try_opt {
+    ($expr: expr) => {
+        match $expr {
+            Some(value) => value,
+            None => return None
+        }
+    }
+}
+
+impl Lenv {
+    pub fn add_builtin(&mut self, name: &str, func: Lbuiltin) {
+            let lval = Lval::lval_fun(func);
+            self.borrow_mut().insert(name.to_string(), lval);
+    }
+
+    pub fn put(&self, k: String, v: Lval) {
+        self.borrow_mut().insert(k, v);
+    }
+
+    pub fn def(&self, k: String, v: Lval){
+        match self.parent() {
+            Some(parent) => {
+                parent.def(k, v)
+            },
+            None => {
+                self.put(k, v)
+            }
+        }
+    }
+
+    pub fn get(&self, k: String) -> Lval {
+        match self.borrow().get(&k) {
+            Some(v) => {
+                v.clone()
+            },
+            None => {
+                match self.parent() {
+                    Some(parent) => {
+                        parent.get(k)
+                    },
+                    None => {
+                        Lval::lval_err(format!("Can't fing {}", k))
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn contains(&self, k: String) -> bool {
+            self.borrow().contains_key(&k)
+    }
+
+}
+
+impl Lenv {
+    /// Create a new node from its associated data.
+    pub fn new() -> Lenv {
+        Lenv(Rc::new(RefCell::new(Node {
+            parent: None,
+            first_child: None,
+            last_child: None,
+            previous_sibling: None,
+            next_sibling: None,
+            data: HashMap::new(),
+        })))
+    }
+
+    /// Return a reference to the parent node, unless this node is the root of the tree.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn parent(&self) -> Option<Lenv> {
+        Some(Lenv(try_opt!(try_opt!(self.0.borrow().parent.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the first child of this node, unless it has no child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn first_child(&self) -> Option<Lenv> {
+        Some(Lenv(try_opt!(self.0.borrow().first_child.as_ref()).clone()))
+    }
+
+    /// Return a reference to the last child of this node, unless it has no child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn last_child(&self) -> Option<Lenv> {
+        Some(Lenv(try_opt!(try_opt!(self.0.borrow().last_child.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the previous sibling of this node, unless it is a first child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn previous_sibling(&self) -> Option<Lenv> {
+        Some(Lenv(try_opt!(try_opt!(self.0.borrow().previous_sibling.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the previous sibling of this node, unless it is a first child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn next_sibling(&self) -> Option<Lenv> {
+        Some(Lenv(try_opt!(self.0.borrow().next_sibling.as_ref()).clone()))
+    }
+
+    /// Return a shared reference to this node’s data
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn borrow(&self) -> Ref{
+        Ref { _ref: self.0.borrow() }
+    }
+
+    /// Return a unique/mutable reference to this node’s data
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently borrowed.
+    pub fn borrow_mut(&self) -> RefMut {
+        RefMut { _ref: self.0.borrow_mut() }
+    }
+
+    /// Returns whether two references point to the same node.
+    pub fn same_node(&self, other: &Lenv) -> bool {
+        same_rc(&self.0, &other.0)
+    }
+
+    /// Return an iterator of references to this node and its ancestors.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn ancestors(&self) -> Ancestors {
+        Ancestors(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node and the siblings before it.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn preceding_siblings(&self) -> PrecedingSiblings {
+        PrecedingSiblings(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node and the siblings after it.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn following_siblings(&self) -> FollowingSiblings {
+        FollowingSiblings(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node’s children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn children(&self) -> Children {
+        Children(self.first_child())
+    }
+
+    /// Return an iterator of references to this node’s children, in reverse order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn reverse_children(&self) -> ReverseChildren {
+        ReverseChildren(self.last_child())
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    ///
+    /// Parent nodes appear before the descendants.
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn descendants(&self) -> Descendants {
+        Descendants(self.traverse())
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    pub fn traverse(&self) -> Traverse {
+        Traverse {
+            root: self.clone(),
+            next: Some(NodeEdge::Start(self.clone())),
+        }
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    pub fn reverse_traverse(&self) -> ReverseTraverse {
+        ReverseTraverse {
+            root: self.clone(),
+            next: Some(NodeEdge::End(self.clone())),
+        }
+    }
+
+    /// Detach a node from its parent and siblings. Children are not affected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node or one of its adjoining nodes is currently borrowed.
+    pub fn detach(&self) {
+        self.0.borrow_mut().detach();
+    }
+
+    /// Append a new child to this node, after existing children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new child, or one of their adjoining nodes is currently borrowed.
+    pub fn append(&self, new_child: Lenv) {
+        let mut self_borrow = self.0.borrow_mut();
+        let mut last_child_opt = None;
+        {
+            let mut new_child_borrow = new_child.0.borrow_mut();
+            new_child_borrow.detach();
+            new_child_borrow.parent = Some(Rc::downgrade(&self.0));
+            if let Some(last_child_weak) = self_borrow.last_child.take() {
+                if let Some(last_child_strong) = last_child_weak.upgrade() {
+                    new_child_borrow.previous_sibling = Some(last_child_weak);
+                    last_child_opt = Some(last_child_strong);
+                }
+            }
+            self_borrow.last_child = Some(Rc::downgrade(&new_child.0));
+        }
+
+        if let Some(last_child_strong) = last_child_opt {
+            let mut last_child_borrow = last_child_strong.borrow_mut();
+            debug_assert!(last_child_borrow.next_sibling.is_none());
+            last_child_borrow.next_sibling = Some(new_child.0);
+        } else {
+            // No last child
+            debug_assert!(self_borrow.first_child.is_none());
+            self_borrow.first_child = Some(new_child.0);
+        }
+    }
+
+    /// Prepend a new child to this node, before existing children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new child, or one of their adjoining nodes is currently borrowed.
+    pub fn prepend(&self, new_child: Lenv) {
+        let mut self_borrow = self.0.borrow_mut();
+        {
+            let mut new_child_borrow = new_child.0.borrow_mut();
+            new_child_borrow.detach();
+            new_child_borrow.parent = Some(Rc::downgrade(&self.0));
+            match self_borrow.first_child.take() {
+                Some(first_child_strong) => {
+                    {
+                        let mut first_child_borrow = first_child_strong.borrow_mut();
+                        debug_assert!(first_child_borrow.previous_sibling.is_none());
+                        first_child_borrow.previous_sibling = Some(Rc::downgrade(&new_child.0));
+                    }
+                    new_child_borrow.next_sibling = Some(first_child_strong);
+                }
+                None => {
+                    debug_assert!(self_borrow.first_child.is_none());
+                    self_borrow.last_child = Some(Rc::downgrade(&new_child.0));
+                }
+            }
+        }
+        self_borrow.first_child = Some(new_child.0);
+    }
+
+    /// Insert a new sibling after this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new sibling, or one of their adjoining nodes is currently borrowed.
+    pub fn insert_after(&self, new_sibling: Lenv) {
+        let mut self_borrow = self.0.borrow_mut();
+        {
+            let mut new_sibling_borrow = new_sibling.0.borrow_mut();
+            new_sibling_borrow.detach();
+            new_sibling_borrow.parent = self_borrow.parent.clone();
+            new_sibling_borrow.previous_sibling = Some(Rc::downgrade(&self.0));
+            match self_borrow.next_sibling.take() {
+                Some(next_sibling_strong) => {
+                    {
+                        let mut next_sibling_borrow = next_sibling_strong.borrow_mut();
+                        debug_assert!({
+                            let weak = next_sibling_borrow.previous_sibling.as_ref().unwrap();
+                            same_rc(&weak.upgrade().unwrap(), &self.0)
+                        });
+                        next_sibling_borrow.previous_sibling = Some(Rc::downgrade(&new_sibling.0));
+                    }
+                    new_sibling_borrow.next_sibling = Some(next_sibling_strong);
+                }
+                None => {
+                    if let Some(parent_ref) = self_borrow.parent.as_ref() {
+                        if let Some(parent_strong) = parent_ref.upgrade() {
+                            let mut parent_borrow = parent_strong.borrow_mut();
+                            parent_borrow.last_child = Some(Rc::downgrade(&new_sibling.0));
+                        }
+                    }
+                }
+            }
+        }
+        self_borrow.next_sibling = Some(new_sibling.0);
+    }
+
+    /// Insert a new sibling before this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new sibling, or one of their adjoining nodes is currently borrowed.
+    pub fn insert_before(&self, new_sibling: Lenv) {
+        let mut self_borrow = self.0.borrow_mut();
+        let mut previous_sibling_opt = None;
+        {
+            let mut new_sibling_borrow = new_sibling.0.borrow_mut();
+            new_sibling_borrow.detach();
+            new_sibling_borrow.parent = self_borrow.parent.clone();
+            new_sibling_borrow.next_sibling = Some(self.0.clone());
+            if let Some(previous_sibling_weak) = self_borrow.previous_sibling.take() {
+                if let Some(previous_sibling_strong) = previous_sibling_weak.upgrade() {
+                    new_sibling_borrow.previous_sibling = Some(previous_sibling_weak);
+                    previous_sibling_opt = Some(previous_sibling_strong);
+                }
+            }
+            self_borrow.previous_sibling = Some(Rc::downgrade(&new_sibling.0));
+        }
+
+        if let Some(previous_sibling_strong) = previous_sibling_opt {
+            let mut previous_sibling_borrow = previous_sibling_strong.borrow_mut();
+            debug_assert!({
+                let rc = previous_sibling_borrow.next_sibling.as_ref().unwrap();
+                same_rc(rc, &self.0)
+            });
+            previous_sibling_borrow.next_sibling = Some(new_sibling.0);
+        } else {
+            // No previous sibling.
+            if let Some(parent_ref) = self_borrow.parent.as_ref() {
+                if let Some(parent_strong) = parent_ref.upgrade() {
+                    let mut parent_borrow = parent_strong.borrow_mut();
+                    parent_borrow.first_child = Some(new_sibling.0);
+                }
+            }
+        }
+    }
+}
+
+/// Wraps a `std::cell::Ref` for a node’s data.
+pub struct Ref<'a> {
+    _ref: cell::Ref<'a, Node>
+}
+
+/// Wraps a `std::cell::RefMut` for a node’s data.
+pub struct RefMut<'a> {
+    _ref: cell::RefMut<'a, Node>
+}
+
+impl<'a> Deref for Ref<'a> {
+    type Target = HashMap<String, Lval>;
+    fn deref(&self) -> & HashMap<String, Lval> { &self._ref.data }
+}
+
+impl<'a> Deref for RefMut<'a> {
+    type Target = HashMap<String, Lval>;
+    fn deref(&self) -> &HashMap<String, Lval> { &self._ref.data }
+}
+
+impl<'a> DerefMut for RefMut<'a> {
+    fn deref_mut(&mut self) -> &mut HashMap<String, Lval> { &mut self._ref.data }
+}
+
+
+impl Node {
+    /// Detach a node from its parent and siblings. Children are not affected.
+    fn detach(&mut self) {
+        let parent_weak = self.parent.take();
+        let previous_sibling_weak = self.previous_sibling.take();
+        let next_sibling_strong = self.next_sibling.take();
+
+        let previous_sibling_opt = previous_sibling_weak.as_ref().and_then(|weak| weak.upgrade());
+
+        if let Some(next_sibling_ref) = next_sibling_strong.as_ref() {
+            let mut next_sibling_borrow = next_sibling_ref.borrow_mut();
+            next_sibling_borrow.previous_sibling = previous_sibling_weak;
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                let mut parent_borrow = parent_strong.borrow_mut();
+                parent_borrow.last_child = previous_sibling_weak;
+            }
+        }
+
+        if let Some(previous_sibling_strong) = previous_sibling_opt {
+            let mut previous_sibling_borrow = previous_sibling_strong.borrow_mut();
+            previous_sibling_borrow.next_sibling = next_sibling_strong;
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                let mut parent_borrow = parent_strong.borrow_mut();
+                parent_borrow.first_child = next_sibling_strong;
+            }
+        }
+    }
+}
+
+
+macro_rules! impl_node_iterator {
+    ($name: ident, $next: expr) => {
+        impl Iterator for $name {
+            type Item = Lenv;
+
+            /// # Panics
+            ///
+            /// Panics if the node about to be yielded is currently mutability borrowed.
+            fn next(&mut self) -> Option<Lenv> {
+                match self.0.take() {
+                    Some(node) => {
+                        self.0 = $next(&node);
+                        Some(node)
+                    }
+                    None => None
+                }
+            }
+        }
+    }
+}
+
+/// An iterator of references to the ancestors a given node.
+pub struct Ancestors(Option<Lenv>);
+impl_node_iterator!(Ancestors, |node: &Lenv| node.parent());
+
+/// An iterator of references to the siblings before a given node.
+pub struct PrecedingSiblings(Option<Lenv>);
+impl_node_iterator!(PrecedingSiblings, |node: &Lenv| node.previous_sibling());
+
+/// An iterator of references to the siblings after a given node.
+pub struct FollowingSiblings(Option<Lenv>);
+impl_node_iterator!(FollowingSiblings, |node: &Lenv| node.next_sibling());
+
+/// An iterator of references to the children of a given node.
+pub struct Children(Option<Lenv>);
+impl_node_iterator!(Children, |node: &Lenv| node.next_sibling());
+
+/// An iterator of references to the children of a given node, in reverse order.
+pub struct ReverseChildren(Option<Lenv>);
+impl_node_iterator!(ReverseChildren, |node: &Lenv| node.previous_sibling());
+
+
+/// An iterator of references to a given node and its descendants, in tree order.
+pub struct Descendants(Traverse);
+
+impl Iterator for Descendants {
+    type Item = Lenv;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<Lenv> {
+        loop {
+            match self.0.next() {
+                Some(NodeEdge::Start(node)) => return Some(node),
+                Some(NodeEdge::End(_)) => {}
+                None => return None
+            }
+        }
+    }
+}
+
+
+#[derive(Debug, Clone)]
+pub enum NodeEdge {
+    /// Indicates that start of a node that has children.
+    /// Yielded by `Traverse::next` before the node’s descendants.
+    /// In HTML or XML, this corresponds to an opening tag like `<div>`
+    Start(Lenv),
+
+    /// Indicates that end of a node that has children.
+    /// Yielded by `Traverse::next` after the node’s descendants.
+    /// In HTML or XML, this corresponds to a closing tag like `</div>`
+    End(Lenv),
+}
+
+
+/// An iterator of references to a given node and its descendants, in tree order.
+pub struct Traverse {
+    root: Lenv,
+    next: Option<NodeEdge>,
+}
+
+impl Iterator for Traverse {
+    type Item = NodeEdge;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<NodeEdge> {
+        match self.next.take() {
+            Some(item) => {
+                self.next = match item {
+                    NodeEdge::Start(ref node) => {
+                        match node.first_child() {
+                            Some(first_child) => Some(NodeEdge::Start(first_child)),
+                            None => Some(NodeEdge::End(node.clone()))
+                        }
+                    }
+                    NodeEdge::End(ref node) => {
+                        if node.same_node(&self.root) {
+                            None
+                        } else {
+                            match node.next_sibling() {
+                                Some(next_sibling) => Some(NodeEdge::Start(next_sibling)),
+                                None => match node.parent() {
+                                    Some(parent) => Some(NodeEdge::End(parent)),
+
+                                    // `node.parent()` here can only be `None`
+                                    // if the tree has been modified during iteration,
+                                    // but silently stoping iteration
+                                    // seems a more sensible behavior than panicking.
+                                    None => None
+                                }
+                            }
+                        }
+                    }
+                };
+                Some(item)
+            }
+            None => None
+        }
+    }
+}
+
+/// An iterator of references to a given node and its descendants, in reverse tree order.
+pub struct ReverseTraverse {
+    root: Lenv,
+    next: Option<NodeEdge>,
+}
+
+impl Iterator for ReverseTraverse {
+    type Item = NodeEdge;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<NodeEdge> {
+        match self.next.take() {
+            Some(item) => {
+                self.next = match item {
+                    NodeEdge::End(ref node) => {
+                        match node.last_child() {
+                            Some(last_child) => Some(NodeEdge::End(last_child)),
+                            None => Some(NodeEdge::Start(node.clone()))
+                        }
+                    }
+                    NodeEdge::Start(ref node) => {
+                        if node.same_node(&self.root) {
+                            None
+                        } else {
+                            match node.previous_sibling() {
+                                Some(previous_sibling) => Some(NodeEdge::End(previous_sibling)),
+                                None => match node.parent() {
+                                    Some(parent) => Some(NodeEdge::Start(parent)),
+
+                                    // `node.parent()` here can only be `None`
+                                    // if the tree has been modified during iteration,
+                                    // but silently stoping iteration
+                                    // seems a more sensible behavior than panicking.
+                                    None => None
+                                }
+                            }
+                        }
+                    }
+                };
+                Some(item)
+            }
+            None => None
+        }
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     #[test]
+//     fn it_works() {
+//         struct DropTracker<'a>(&'a cell::Cell<u32>);
+//         impl<'a> Drop for DropTracker<'a> {
+//             fn drop(&mut self) {
+//                 self.0.set(self.0.get() + 1);
+//             }
+//         }
+//
+//         let mut new_counter = 0;
+//         let drop_counter = cell::Cell::new(0);
+//         let mut new = || {
+//             new_counter += 1;
+//             Lenv::new((new_counter, DropTracker(&drop_counter)))
+//         };
+//
+//         {
+//             let a = new();  // 1
+//             a.append(new());  // 2
+//             a.append(new());  // 3
+//             a.prepend(new());  // 4
+//             let b = new();  // 5
+//             b.append(a.clone());
+//             a.insert_before(new());  // 6
+//             a.insert_before(new());  // 7
+//             a.insert_after(new());  // 8
+//             a.insert_after(new());  // 9
+//             let c = new();  // 10
+//             b.append(c.clone());
+//
+//             assert_eq!(drop_counter.get(), 0);
+//             c.previous_sibling().unwrap().detach();
+//             assert_eq!(drop_counter.get(), 1);
+//
+//             assert_eq!(b.descendants().map(|node| {
+//                 let borrow = node.borrow();
+//                 borrow.0
+//             }).collect::<Vec<_>>(), [
+//                 5, 6, 7, 1, 4, 2, 3, 9, 10
+//             ]);
+//         }
+//
+//         assert_eq!(drop_counter.get(), 10);
+//     }
+// }

--- a/rispreter-repl/src/lval/lval_eval.rs
+++ b/rispreter-repl/src/lval/lval_eval.rs
@@ -1,18 +1,12 @@
 use crate::lval::lval_def::*;
 use crate::lval::lval_builtin;
+use crate::lval::lval_env::Lenv;
 
 pub fn lval_eval(lenv: &mut Lenv, lval: &mut Lval) -> Lval {
     match &lval.ltype {
         LvalType::LVAL_SYM(sym) => {
-            let x = lenv.get(&sym);
-            match x {
-                Some(v) => {
-                    return *v.clone();
-                },
-                None => {
-                    return Lval::lval_err(format!("Can't find {:?}", sym));
-                }
-            }
+            let x = lenv.get(sym.to_string());
+            x
         },
         LvalType::LVAL_SEXPR => {
             return lval_eval_sexpr(lenv, lval);
@@ -68,7 +62,7 @@ pub fn lval_call(lenv: &mut Lenv, f: &mut Lval, lval: &mut Lval) -> Lval {
             let total = lambda.formals.cell.len();
 
             // while arguments still to be processed
-            println!("before binding lambda formals : {:?}", lambda.formals.cell);
+            //println!("before binding lambda formals : {:?}", lambda.formals.cell);
 
             while lval.cell.len() > 0 {
                 //println!("lval cell len: {}", lval.cell.len());
@@ -85,7 +79,7 @@ pub fn lval_call(lenv: &mut Lenv, f: &mut Lval, lval: &mut Lval) -> Lval {
                     if s == "&" {
                         //TODO ensure its followd by another symbol
                         let next_sym = lambda.formals.lval_pop();
-                        lambda.local_lenv.put(next_sym.to_string(), Box::new(lval_builtin::list(lenv, lval)));
+                        lambda.local_lenv.put(next_sym.to_string(), lval_builtin::list(lenv, lval));
                         break;
                     }
                 }
@@ -95,16 +89,32 @@ pub fn lval_call(lenv: &mut Lenv, f: &mut Lval, lval: &mut Lval) -> Lval {
                 let val = lval.lval_pop();
 
                 // bind a copy to the lambda local env
-                lambda.local_lenv.put(sym.to_string(), Box::new(val));
+                lambda.local_lenv.put(sym.to_string(), val);
             };
-            println!("after binding lambda formals : {:?}", lambda.formals.cell);
+            //println!("after binding lambda formals : {:?}", lambda.formals.cell);
             // if all formals have been bound evaluate
             if lambda.formals.cell.len() == 0 {
                 //set enviroment parent to evaluation enviroment
-                // TODO: this should't be cloned
-                lambda.local_lenv.paren_env = Some(Box::new(lenv.clone()));
+                //lambda.local_lenv.paren_env = Some(Box::new(lenv.clone()));
+                // println!("lenv before: {:?}", lenv);
+                // match lenv.first_child() {
+                //     Some(child) => {
+                //         child.detach();
+                //         lenv.append(child);
+                //     },
+                //     None => {
+                //         lenv.append(*lambda.local_lenv);
+                //     }
+                // }
+                //
+                // println!("lenv after: {:?}", lenv);
+                // if let Some(child) = lenv.first_child() {
+                //     child.detach()
+                // }
+                lenv.append(*lambda.local_lenv);
+                //println!("lenv: {:?}", lenv);
+                return lval_builtin::eval(&mut lenv.first_child().unwrap(), Lval::lval_sexpr().add_cell(*lambda.body.clone()))
 
-                return lval_builtin::eval(&mut lambda.local_lenv, Lval::lval_sexpr().add_cell(*lambda.body.clone()))
 
             } else {
                 return Lval::lval_lambda_copy(*lambda.local_lenv, *lambda.formals, *lambda.body)
@@ -120,6 +130,7 @@ pub fn lval_call(lenv: &mut Lenv, f: &mut Lval, lval: &mut Lval) -> Lval {
 pub mod tests {
     use super::*;
     use crate::lval::lval_builtin::*;
+    use crate::lval::lval_env::Lenv;
     // use crate::lval_def::*;
 
     #[test]

--- a/rispreter-repl/src/lval/lval_eval.rs
+++ b/rispreter-repl/src/lval/lval_eval.rs
@@ -204,6 +204,6 @@ pub mod tests {
         qexpr.add_cell(a).add_cell(b).add_cell(c);
         top.add_cell(head).add_cell(qexpr);
         let res = lval_eval(&mut env, &mut top);
-        assert_eq!(res.ltype, LvalType::LVAL_NUM(1.0));
+        assert_eq!(res.cell[0].ltype, LvalType::LVAL_NUM(1.0));
     }
 }

--- a/rispreter-repl/src/lval/lval_lambda.rs
+++ b/rispreter-repl/src/lval/lval_lambda.rs
@@ -1,4 +1,5 @@
 use crate::lval::lval_def::*;
+use crate::lval::lval_env::Lenv;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct LLambda {

--- a/rispreter-repl/src/lval/mod.rs
+++ b/rispreter-repl/src/lval/mod.rs
@@ -2,3 +2,4 @@ pub mod lval_def;
 pub mod lval_builtin;
 pub mod lval_eval;
 pub mod lval_lambda;
+pub mod lval_env;

--- a/rispreter-repl/src/refnode.rs
+++ b/rispreter-repl/src/refnode.rs
@@ -1,0 +1,627 @@
+use std::cell::{self, RefCell};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::rc::{Rc, Weak};
+
+
+/// A reference to a node holding a value of type `T`. Nodes form a tree.
+///
+/// Internally, this uses reference counting for lifetime tracking
+/// and `std::cell::RefCell` for interior mutability.
+///
+/// **Note:** Cloning a `NodeRef` only increments a reference count. It does not copy the data.
+pub struct NodeRef<T>(Rc<RefCell<Node<T>>>);
+
+struct Node<T> {
+    parent: WeakLink<T>,
+    first_child: Link<T>,
+    last_child: WeakLink<T>,
+    previous_sibling: WeakLink<T>,
+    next_sibling: Link<T>,
+    data: T,
+}
+
+type Link<T> = Option<Rc<RefCell<Node<T>>>>;
+type WeakLink<T> = Option<Weak<RefCell<Node<T>>>>;
+
+
+fn same_rc<T>(a: &Rc<T>, b: &Rc<T>) -> bool {
+    let a: *const T = &**a;
+    let b: *const T = &**b;
+    a == b
+}
+
+
+/// Cloning a `NodeRef` only increments a reference count. It does not copy the data.
+impl<T> Clone for NodeRef<T> {
+    fn clone(&self) -> NodeRef<T> {
+        NodeRef(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for NodeRef<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&*self.borrow(), f)
+    }
+}
+
+macro_rules! try_opt {
+    ($expr: expr) => {
+        match $expr {
+            Some(value) => value,
+            None => return None
+        }
+    }
+}
+
+
+impl<T> NodeRef<T> {
+    /// Create a new node from its associated data.
+    pub fn new(data: T) -> NodeRef<T> {
+        NodeRef(Rc::new(RefCell::new(Node {
+            parent: None,
+            first_child: None,
+            last_child: None,
+            previous_sibling: None,
+            next_sibling: None,
+            data,
+        })))
+    }
+
+    /// Return a reference to the parent node, unless this node is the root of the tree.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn parent(&self) -> Option<NodeRef<T>> {
+        Some(NodeRef(try_opt!(try_opt!(self.0.borrow().parent.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the first child of this node, unless it has no child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn first_child(&self) -> Option<NodeRef<T>> {
+        Some(NodeRef(try_opt!(self.0.borrow().first_child.as_ref()).clone()))
+    }
+
+    /// Return a reference to the last child of this node, unless it has no child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn last_child(&self) -> Option<NodeRef<T>> {
+        Some(NodeRef(try_opt!(try_opt!(self.0.borrow().last_child.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the previous sibling of this node, unless it is a first child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn previous_sibling(&self) -> Option<NodeRef<T>> {
+        Some(NodeRef(try_opt!(try_opt!(self.0.borrow().previous_sibling.as_ref()).upgrade())))
+    }
+
+    /// Return a reference to the previous sibling of this node, unless it is a first child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn next_sibling(&self) -> Option<NodeRef<T>> {
+        Some(NodeRef(try_opt!(self.0.borrow().next_sibling.as_ref()).clone()))
+    }
+
+    /// Return a shared reference to this node’s data
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn borrow(&self) -> Ref<T> {
+        Ref { _ref: self.0.borrow() }
+    }
+
+    /// Return a unique/mutable reference to this node’s data
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently borrowed.
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        RefMut { _ref: self.0.borrow_mut() }
+    }
+
+    /// Returns whether two references point to the same node.
+    pub fn same_node(&self, other: &NodeRef<T>) -> bool {
+        same_rc(&self.0, &other.0)
+    }
+
+    /// Return an iterator of references to this node and its ancestors.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn ancestors(&self) -> Ancestors<T> {
+        Ancestors(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node and the siblings before it.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn preceding_siblings(&self) -> PrecedingSiblings<T> {
+        PrecedingSiblings(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node and the siblings after it.
+    ///
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn following_siblings(&self) -> FollowingSiblings<T> {
+        FollowingSiblings(Some(self.clone()))
+    }
+
+    /// Return an iterator of references to this node’s children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn children(&self) -> Children<T> {
+        Children(self.first_child())
+    }
+
+    /// Return an iterator of references to this node’s children, in reverse order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node is currently mutability borrowed.
+    pub fn reverse_children(&self) -> ReverseChildren<T> {
+        ReverseChildren(self.last_child())
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    ///
+    /// Parent nodes appear before the descendants.
+    /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    pub fn descendants(&self) -> Descendants<T> {
+        Descendants(self.traverse())
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    pub fn traverse(&self) -> Traverse<T> {
+        Traverse {
+            root: self.clone(),
+            next: Some(NodeEdge::Start(self.clone())),
+        }
+    }
+
+    /// Return an iterator of references to this node and its descendants, in tree order.
+    pub fn reverse_traverse(&self) -> ReverseTraverse<T> {
+        ReverseTraverse {
+            root: self.clone(),
+            next: Some(NodeEdge::End(self.clone())),
+        }
+    }
+
+    /// Detach a node from its parent and siblings. Children are not affected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node or one of its adjoining nodes is currently borrowed.
+    pub fn detach(&self) {
+        self.0.borrow_mut().detach();
+    }
+
+    /// Append a new child to this node, after existing children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new child, or one of their adjoining nodes is currently borrowed.
+    pub fn append(&self, new_child: NodeRef<T>) {
+        let mut self_borrow = self.0.borrow_mut();
+        let mut last_child_opt = None;
+        {
+            let mut new_child_borrow = new_child.0.borrow_mut();
+            new_child_borrow.detach();
+            new_child_borrow.parent = Some(Rc::downgrade(&self.0));
+            if let Some(last_child_weak) = self_borrow.last_child.take() {
+                if let Some(last_child_strong) = last_child_weak.upgrade() {
+                    new_child_borrow.previous_sibling = Some(last_child_weak);
+                    last_child_opt = Some(last_child_strong);
+                }
+            }
+            self_borrow.last_child = Some(Rc::downgrade(&new_child.0));
+        }
+
+        if let Some(last_child_strong) = last_child_opt {
+            let mut last_child_borrow = last_child_strong.borrow_mut();
+            debug_assert!(last_child_borrow.next_sibling.is_none());
+            last_child_borrow.next_sibling = Some(new_child.0);
+        } else {
+            // No last child
+            debug_assert!(self_borrow.first_child.is_none());
+            self_borrow.first_child = Some(new_child.0);
+        }
+    }
+
+    /// Prepend a new child to this node, before existing children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new child, or one of their adjoining nodes is currently borrowed.
+    pub fn prepend(&self, new_child: NodeRef<T>) {
+        let mut self_borrow = self.0.borrow_mut();
+        {
+            let mut new_child_borrow = new_child.0.borrow_mut();
+            new_child_borrow.detach();
+            new_child_borrow.parent = Some(Rc::downgrade(&self.0));
+            match self_borrow.first_child.take() {
+                Some(first_child_strong) => {
+                    {
+                        let mut first_child_borrow = first_child_strong.borrow_mut();
+                        debug_assert!(first_child_borrow.previous_sibling.is_none());
+                        first_child_borrow.previous_sibling = Some(Rc::downgrade(&new_child.0));
+                    }
+                    new_child_borrow.next_sibling = Some(first_child_strong);
+                }
+                None => {
+                    debug_assert!(self_borrow.first_child.is_none());
+                    self_borrow.last_child = Some(Rc::downgrade(&new_child.0));
+                }
+            }
+        }
+        self_borrow.first_child = Some(new_child.0);
+    }
+
+    /// Insert a new sibling after this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new sibling, or one of their adjoining nodes is currently borrowed.
+    pub fn insert_after(&self, new_sibling: NodeRef<T>) {
+        let mut self_borrow = self.0.borrow_mut();
+        {
+            let mut new_sibling_borrow = new_sibling.0.borrow_mut();
+            new_sibling_borrow.detach();
+            new_sibling_borrow.parent = self_borrow.parent.clone();
+            new_sibling_borrow.previous_sibling = Some(Rc::downgrade(&self.0));
+            match self_borrow.next_sibling.take() {
+                Some(next_sibling_strong) => {
+                    {
+                        let mut next_sibling_borrow = next_sibling_strong.borrow_mut();
+                        debug_assert!({
+                            let weak = next_sibling_borrow.previous_sibling.as_ref().unwrap();
+                            same_rc(&weak.upgrade().unwrap(), &self.0)
+                        });
+                        next_sibling_borrow.previous_sibling = Some(Rc::downgrade(&new_sibling.0));
+                    }
+                    new_sibling_borrow.next_sibling = Some(next_sibling_strong);
+                }
+                None => {
+                    if let Some(parent_ref) = self_borrow.parent.as_ref() {
+                        if let Some(parent_strong) = parent_ref.upgrade() {
+                            let mut parent_borrow = parent_strong.borrow_mut();
+                            parent_borrow.last_child = Some(Rc::downgrade(&new_sibling.0));
+                        }
+                    }
+                }
+            }
+        }
+        self_borrow.next_sibling = Some(new_sibling.0);
+    }
+
+    /// Insert a new sibling before this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node, the new sibling, or one of their adjoining nodes is currently borrowed.
+    pub fn insert_before(&self, new_sibling: NodeRef<T>) {
+        let mut self_borrow = self.0.borrow_mut();
+        let mut previous_sibling_opt = None;
+        {
+            let mut new_sibling_borrow = new_sibling.0.borrow_mut();
+            new_sibling_borrow.detach();
+            new_sibling_borrow.parent = self_borrow.parent.clone();
+            new_sibling_borrow.next_sibling = Some(self.0.clone());
+            if let Some(previous_sibling_weak) = self_borrow.previous_sibling.take() {
+                if let Some(previous_sibling_strong) = previous_sibling_weak.upgrade() {
+                    new_sibling_borrow.previous_sibling = Some(previous_sibling_weak);
+                    previous_sibling_opt = Some(previous_sibling_strong);
+                }
+            }
+            self_borrow.previous_sibling = Some(Rc::downgrade(&new_sibling.0));
+        }
+
+        if let Some(previous_sibling_strong) = previous_sibling_opt {
+            let mut previous_sibling_borrow = previous_sibling_strong.borrow_mut();
+            debug_assert!({
+                let rc = previous_sibling_borrow.next_sibling.as_ref().unwrap();
+                same_rc(rc, &self.0)
+            });
+            previous_sibling_borrow.next_sibling = Some(new_sibling.0);
+        } else {
+            // No previous sibling.
+            if let Some(parent_ref) = self_borrow.parent.as_ref() {
+                if let Some(parent_strong) = parent_ref.upgrade() {
+                    let mut parent_borrow = parent_strong.borrow_mut();
+                    parent_borrow.first_child = Some(new_sibling.0);
+                }
+            }
+        }
+    }
+}
+
+/// Wraps a `std::cell::Ref` for a node’s data.
+pub struct Ref<'a, T: 'a> {
+    _ref: cell::Ref<'a, Node<T>>
+}
+
+/// Wraps a `std::cell::RefMut` for a node’s data.
+pub struct RefMut<'a, T: 'a> {
+    _ref: cell::RefMut<'a, Node<T>>
+}
+
+impl<'a, T> Deref for Ref<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T { &self._ref.data }
+}
+
+impl<'a, T> Deref for RefMut<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T { &self._ref.data }
+}
+
+impl<'a, T> DerefMut for RefMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut T { &mut self._ref.data }
+}
+
+
+impl<T> Node<T> {
+    /// Detach a node from its parent and siblings. Children are not affected.
+    fn detach(&mut self) {
+        let parent_weak = self.parent.take();
+        let previous_sibling_weak = self.previous_sibling.take();
+        let next_sibling_strong = self.next_sibling.take();
+
+        let previous_sibling_opt = previous_sibling_weak.as_ref().and_then(|weak| weak.upgrade());
+
+        if let Some(next_sibling_ref) = next_sibling_strong.as_ref() {
+            let mut next_sibling_borrow = next_sibling_ref.borrow_mut();
+            next_sibling_borrow.previous_sibling = previous_sibling_weak;
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                let mut parent_borrow = parent_strong.borrow_mut();
+                parent_borrow.last_child = previous_sibling_weak;
+            }
+        }
+
+        if let Some(previous_sibling_strong) = previous_sibling_opt {
+            let mut previous_sibling_borrow = previous_sibling_strong.borrow_mut();
+            previous_sibling_borrow.next_sibling = next_sibling_strong;
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                let mut parent_borrow = parent_strong.borrow_mut();
+                parent_borrow.first_child = next_sibling_strong;
+            }
+        }
+    }
+}
+
+
+macro_rules! impl_node_iterator {
+    ($name: ident, $next: expr) => {
+        impl<T> Iterator for $name<T> {
+            type Item = NodeRef<T>;
+
+            /// # Panics
+            ///
+            /// Panics if the node about to be yielded is currently mutability borrowed.
+            fn next(&mut self) -> Option<NodeRef<T>> {
+                match self.0.take() {
+                    Some(node) => {
+                        self.0 = $next(&node);
+                        Some(node)
+                    }
+                    None => None
+                }
+            }
+        }
+    }
+}
+
+/// An iterator of references to the ancestors a given node.
+pub struct Ancestors<T>(Option<NodeRef<T>>);
+impl_node_iterator!(Ancestors, |node: &NodeRef<T>| node.parent());
+
+/// An iterator of references to the siblings before a given node.
+pub struct PrecedingSiblings<T>(Option<NodeRef<T>>);
+impl_node_iterator!(PrecedingSiblings, |node: &NodeRef<T>| node.previous_sibling());
+
+/// An iterator of references to the siblings after a given node.
+pub struct FollowingSiblings<T>(Option<NodeRef<T>>);
+impl_node_iterator!(FollowingSiblings, |node: &NodeRef<T>| node.next_sibling());
+
+/// An iterator of references to the children of a given node.
+pub struct Children<T>(Option<NodeRef<T>>);
+impl_node_iterator!(Children, |node: &NodeRef<T>| node.next_sibling());
+
+/// An iterator of references to the children of a given node, in reverse order.
+pub struct ReverseChildren<T>(Option<NodeRef<T>>);
+impl_node_iterator!(ReverseChildren, |node: &NodeRef<T>| node.previous_sibling());
+
+
+/// An iterator of references to a given node and its descendants, in tree order.
+pub struct Descendants<T>(Traverse<T>);
+
+impl<T> Iterator for Descendants<T> {
+    type Item = NodeRef<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<NodeRef<T>> {
+        loop {
+            match self.0.next() {
+                Some(NodeEdge::Start(node)) => return Some(node),
+                Some(NodeEdge::End(_)) => {}
+                None => return None
+            }
+        }
+    }
+}
+
+
+#[derive(Debug, Clone)]
+pub enum NodeEdge<T> {
+    /// Indicates that start of a node that has children.
+    /// Yielded by `Traverse::next` before the node’s descendants.
+    /// In HTML or XML, this corresponds to an opening tag like `<div>`
+    Start(NodeRef<T>),
+
+    /// Indicates that end of a node that has children.
+    /// Yielded by `Traverse::next` after the node’s descendants.
+    /// In HTML or XML, this corresponds to a closing tag like `</div>`
+    End(NodeRef<T>),
+}
+
+
+/// An iterator of references to a given node and its descendants, in tree order.
+pub struct Traverse<T> {
+    root: NodeRef<T>,
+    next: Option<NodeEdge<T>>,
+}
+
+impl<T> Iterator for Traverse<T> {
+    type Item = NodeEdge<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<NodeEdge<T>> {
+        match self.next.take() {
+            Some(item) => {
+                self.next = match item {
+                    NodeEdge::Start(ref node) => {
+                        match node.first_child() {
+                            Some(first_child) => Some(NodeEdge::Start(first_child)),
+                            None => Some(NodeEdge::End(node.clone()))
+                        }
+                    }
+                    NodeEdge::End(ref node) => {
+                        if node.same_node(&self.root) {
+                            None
+                        } else {
+                            match node.next_sibling() {
+                                Some(next_sibling) => Some(NodeEdge::Start(next_sibling)),
+                                None => match node.parent() {
+                                    Some(parent) => Some(NodeEdge::End(parent)),
+
+                                    // `node.parent()` here can only be `None`
+                                    // if the tree has been modified during iteration,
+                                    // but silently stoping iteration
+                                    // seems a more sensible behavior than panicking.
+                                    None => None
+                                }
+                            }
+                        }
+                    }
+                };
+                Some(item)
+            }
+            None => None
+        }
+    }
+}
+
+/// An iterator of references to a given node and its descendants, in reverse tree order.
+pub struct ReverseTraverse<T> {
+    root: NodeRef<T>,
+    next: Option<NodeEdge<T>>,
+}
+
+impl<T> Iterator for ReverseTraverse<T> {
+    type Item = NodeEdge<T>;
+
+    /// # Panics
+    ///
+    /// Panics if the node about to be yielded is currently mutability borrowed.
+    fn next(&mut self) -> Option<NodeEdge<T>> {
+        match self.next.take() {
+            Some(item) => {
+                self.next = match item {
+                    NodeEdge::End(ref node) => {
+                        match node.last_child() {
+                            Some(last_child) => Some(NodeEdge::End(last_child)),
+                            None => Some(NodeEdge::Start(node.clone()))
+                        }
+                    }
+                    NodeEdge::Start(ref node) => {
+                        if node.same_node(&self.root) {
+                            None
+                        } else {
+                            match node.previous_sibling() {
+                                Some(previous_sibling) => Some(NodeEdge::End(previous_sibling)),
+                                None => match node.parent() {
+                                    Some(parent) => Some(NodeEdge::Start(parent)),
+
+                                    // `node.parent()` here can only be `None`
+                                    // if the tree has been modified during iteration,
+                                    // but silently stoping iteration
+                                    // seems a more sensible behavior than panicking.
+                                    None => None
+                                }
+                            }
+                        }
+                    }
+                };
+                Some(item)
+            }
+            None => None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn it_works() {
+        struct DropTracker<'a>(&'a cell::Cell<u32>);
+        impl<'a> Drop for DropTracker<'a> {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let mut new_counter = 0;
+        let drop_counter = cell::Cell::new(0);
+        let mut new = || {
+            new_counter += 1;
+            NodeRef::new((new_counter, DropTracker(&drop_counter)))
+        };
+
+        {
+            let a = new();  // 1
+            a.append(new());  // 2
+            a.append(new());  // 3
+            a.prepend(new());  // 4
+            let b = new();  // 5
+            b.append(a.clone());
+            a.insert_before(new());  // 6
+            a.insert_before(new());  // 7
+            a.insert_after(new());  // 8
+            a.insert_after(new());  // 9
+            let c = new();  // 10
+            b.append(c.clone());
+
+            assert_eq!(drop_counter.get(), 0);
+            c.previous_sibling().unwrap().detach();
+            assert_eq!(drop_counter.get(), 1);
+
+            assert_eq!(b.descendants().map(|node| {
+                let borrow = node.borrow();
+                borrow.0
+            }).collect::<Vec<_>>(), [
+                5, 6, 7, 1, 4, 2, 3, 9, 10
+            ]);
+        }
+
+        assert_eq!(drop_counter.get(), 10);
+    }
+}

--- a/rispreter-repl/src/repl/mod.rs
+++ b/rispreter-repl/src/repl/mod.rs
@@ -1,4 +1,4 @@
-use crate::lval::lval_def::*;
+use crate::lval::lval_env::Lenv;
 use crate::lval::lval_builtin::*;
 use crate::eval::eval_rispreter;
 
@@ -26,7 +26,9 @@ impl RispRepl {
 
         while let ReadResult::Input(line) = interface.read_line()? {
             println!("{}", eval_rispreter(&mut self.env, line.to_string()));
-
+            for child in self.env.children() {
+                child.detach();
+            }
             if !line.trim().is_empty() {
                 interface.add_history_unique(line);
             }


### PR DESCRIPTION
refactoring of `Lenv` struct. Now it use a custom version of the https://github.com/SimonSapin/rust-forest rctree. This is a very useful data structure to work on the environment logic. On future (and on the best case) this will be expanded to use in spawn/process communication on a top of a actor system implementation, or a least implement some cool ideas using it.
